### PR TITLE
Do not use 'Content-Type' header to determine mode

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -21,20 +21,14 @@ async function init () {
       TextView: TextView,
       TextEdit: TextEditMode
     };
-    let mediaType = await window.fetch(manifest.image).then(response => {
-      if (response.ok) {
-        return response.headers.get('Content-Type');
-      } else {
-        throw new Error(response.statusText);
-      }
-    });
-    // Use media type to set which view and edit modules to use.
-    // let isSinglePage = mediaType.match(/^image\/*/);
-    // params.View = isSinglePage ? SingleView : DivaView;
-    // params.NeumeEdit = isSinglePage ? SingleEditMode : DivaEdit;
-    // TODO this is a debugging fix do not merge.
-    params.View = SingleView;
-    params.NeumeEdit = SingleEditMode;
+
+    let pageCount = manifest['mei_annotations'].length;
+    if (pageCount === 0) {
+      throw new Error('At least one page is required in \'mei_annotations\'! 0 provided.');
+    }
+
+    params.View = pageCount > 1 ? DivaView : SingleView;
+    params.NeumeEdit = pageCount > 1 ? DivaEdit : SingleEditMode;
 
     // Start Neon
     view = new NeonView(params);

--- a/editor.js
+++ b/editor.js
@@ -29,9 +29,12 @@ async function init () {
       }
     });
     // Use media type to set which view and edit modules to use.
-    let isSinglePage = mediaType.match(/^image\/*/);
-    params.View = isSinglePage ? SingleView : DivaView;
-    params.NeumeEdit = isSinglePage ? SingleEditMode : DivaEdit;
+    // let isSinglePage = mediaType.match(/^image\/*/);
+    // params.View = isSinglePage ? SingleView : DivaView;
+    // params.NeumeEdit = isSinglePage ? SingleEditMode : DivaEdit;
+    // TODO this is a debugging fix do not merge.
+    params.View = SingleView;
+    params.NeumeEdit = SingleEditMode;
 
     // Start Neon
     view = new NeonView(params);


### PR DESCRIPTION
Fix #24. Rather than checking the content type of whatever is in the `image` field of the manifest, just check the number of annotations required. Currently this should always be 1 and that will map to the single page viewer.

Ideally nothing will need to be changed with this whenever the wrapper is able to support multiple pages.